### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # .github-workflows-stale.yml
+name: Close Stale Issues
+on:
+  schedule:
+    - cron: '0 12 * * *' # 每天晚上 8:00 (台灣時間)
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9.1.0
+        with:
+          stale-issue-message: 'Old issue!'
+          days-before-stale: 30
+          days-before-close: 7


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate the process of closing stale issues in the repository. The workflow is scheduled to run daily and uses the `actions/stale` action to mark and close issues based on inactivity.

Key addition:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R2-R14): Introduced a new workflow named "Close Stale Issues" that runs daily at 8:00 PM Taiwan time. It marks issues as stale after 30 days of inactivity and closes them after an additional 7 days.name: Close Stale Issues
on:
  schedule:
    - cron: '0 12 * * *' # 每天晚上 8:00 (台灣時間) jobs:
  stale:
    runs-on: ubuntu-latest steps:
      - uses: actions/stale@v9.1.0 with: stale-issue-message: 'Old issue!' days-before-stale: 30 days-before-close: 7
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added instructions in the README for a GitHub Actions workflow that marks issues as stale after 30 days of inactivity and closes them after 7 more days. The workflow runs daily at 8:00 PM Taiwan time.

<!-- End of auto-generated description by cubic. -->

