### PR TITLE
Stale.yml

### DIFF
--- a/V2.yml
+++ b/V2.yml
@@ -1,32 +1,19 @@
-# This is a basic workflow that is manually triggered
+name: Close Stale Issues
 
-name: Manual workflow
-
-# Controls when the action will run. Workflow runs when manually triggered using the UI
-# or API.
 on:
-  workflow_dispatch:
-    # Inputs the workflow accepts.
-    inputs:
-      name:
-        # Friendly description to be shown in the UI instead of 'name'
-        description: 'Person to greet'
-        # Default value if no value is explicitly provided
-        default: 'World'
-        # Input has to be provided for the workflow to run
-        required: true
-        # The data type of the input
-        type: string
+  schedule:
+    - cron: '0 12 * * *' # 每天晚上8:00 (台灣時間)
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "greet"
-  greet:
-    # The type of runner that the job will run on
+  stale:
     runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    # Runs a single command using the runners shell
-    - name: Send greeting
-      run: echo "Hello ${{ inputs.name }}"
+      - uses: actions/checkout@v4
+      - uses: actions/stale@v9.1.0
+        with:
+          stale-issue-message: '這個 Issue 過期了，將在 7 天後關閉！'
+          days-before-stale: 30
+          days-before-close: 7
+          stale-label: 'stale'
+          exempt-labels: 'pinned,security'
+          delete-branch: true


### PR DESCRIPTION
This pull request updates the `V2.yml` workflow file to automate the process of closing stale issues. The changes replace a manually triggered workflow with a scheduled job and integrate the `actions/stale` GitHub Action for managing stale issues.

### Workflow Automation Changes:

* **Workflow Name and Trigger**:
  - Renamed the workflow to "Close Stale Issues" and replaced the manual `workflow_dispatch` trigger with a scheduled cron job that runs daily at 8:00 PM Taiwan time.

* **Job Configuration**:
  - Removed the "greet" job and added a new "stale" job that uses the `actions/stale@v9.1.0` GitHub Action to identify and close stale issues.

* **Stale Issue Management**:
  - Configured the `actions/stale` action with parameters such as a 30-day threshold for marking issues as stale, a 7-day grace period before closing, custom messages, and labels to exempt certain issues.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Replaced the manual workflow in V2.yml with a scheduled job that uses actions/stale to automatically mark and close stale issues.

- **Workflow Changes**
  - Runs daily at 8:00 PM Taiwan time.
  - Marks issues as stale after 30 days and closes them after 7 more days.
  - Exempts issues with "pinned" or "security" labels.

<!-- End of auto-generated description by cubic. -->

